### PR TITLE
fixup! Fix encore-service not copied to proper path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build encore jni
 on:
   workflow_dispatch:
+  push:
+    branches: ["main"]
 
 jobs:
   build:

--- a/module/install.sh
+++ b/module/install.sh
@@ -33,8 +33,7 @@ elif [ $ARCH = "arm" ]; then
 	ui_print "- Copying arm32 libs"
 	cp $TMPDIR/libs/armeabi-v7a/encore-service $MODPATH/system/bin/
 else
-	ui_print "- Unsupported ARCH: $ARCH"
-	exit 1
+	abort "- Unsupported ARCH: $ARCH"
 fi
 
 echo 0 >/data/encore/skip_setpriority

--- a/module/install.sh
+++ b/module/install.sh
@@ -21,17 +21,17 @@ ui_print "- Extracting module files"
 
 mkdir /data/encore
 unzip -o "$ZIPFILE" 'system/*' -d $MODPATH >&2
-unzip -o "$ZIPFILE" 'libs/*' -d $MODPATH >&2
+unzip -o "$ZIPFILE" 'libs/*' -d $TMPDIR >&2
 unzip -o "$ZIPFILE" 'service.sh' -d "$MODPATH" >&2
 unzip -o "$ZIPFILE" 'gamelist.txt' -d "/data/encore" >&2
 unzip -o "$ZIPFILE" 'AppMonitoringUtil.sh' -d "/data/encore" >&2
 
 if [ $ARCH = "arm64" ]; then
 	ui_print "- Copying arm64 libs"
-	cp $TMPDIR/libs/arm64-v8a/encore-service $TMPDIR/system/bin/
+	cp $TMPDIR/libs/arm64-v8a/encore-service $MODPATH/system/bin/
 elif [ $ARCH = "arm" ]; then
 	ui_print "- Copying arm32 libs"
-	cp $TMPDIR/libs/armeabi-v7a/encore-service $TMPDIR/system/bin/
+	cp $TMPDIR/libs/armeabi-v7a/encore-service $MODPATH/system/bin/
 else
 	ui_print "- Unsupported ARCH: $ARCH"
 	exit 1


### PR DESCRIPTION
I messed up between `$TMPDIR` and `$MODPATH`

- Previously:
```bash
unzip -o "$ZIPFILE" 'system/*' -d $MODPATH >&2
unzip -o "$ZIPFILE" 'libs/*' -d $MODPATH >&2
unzip -o "$ZIPFILE" 'service.sh' -d "$MODPATH" >&2
unzip -o "$ZIPFILE" 'gamelist.txt' -d "/data/encore" >&2
unzip -o "$ZIPFILE" 'AppMonitoringUtil.sh' -d "/data/encore" >&2

if [ $ARCH = "arm64" ]; then
	ui_print "- Copying arm64 libs"
	cp $TMPDIR/libs/arm64-v8a/encore-service $MODPATH/system/bin/
elif [ $ARCH = "arm" ]; then
	ui_print "- Copying arm32 libs"
	cp $TMPDIR/libs/armeabi-v7a/encore-service $MODPATH/system/bin/
else
	ui_print "- Unsupported ARCH: $ARCH"
	exit 1
fi
```

- Fixed:
```bash
unzip -o "$ZIPFILE" 'system/*' -d $MODPATH >&2
unzip -o "$ZIPFILE" 'libs/*' -d $TMPDIR >&2
unzip -o "$ZIPFILE" 'service.sh' -d "$MODPATH" >&2
unzip -o "$ZIPFILE" 'gamelist.txt' -d "/data/encore" >&2
unzip -o "$ZIPFILE" 'AppMonitoringUtil.sh' -d "/data/encore" >&2

if [ $ARCH = "arm64" ]; then
	ui_print "- Copying arm64 libs"
	cp $TMPDIR/libs/arm64-v8a/encore-service $MODPATH/system/bin/
elif [ $ARCH = "arm" ]; then
	ui_print "- Copying arm32 libs"
	cp $TMPDIR/libs/armeabi-v7a/encore-service $MODPATH/system/bin/
else
	ui_print "- Unsupported ARCH: $ARCH"
	exit 1
fi
```

Tested on A10s, with KernelSU-On-Arm32.