### PR TITLE
[Bump] Plugin Version For Workflows And Added Checks On Pull_Request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build Encore Zip
 
 on:
+  pull_request:
+    branches:
+      -main
   workflow_dispatch:
   push:
     branches:
@@ -26,17 +29,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
       with:
         fetch-depth: 0
 
     - name: NDK Setup
-      uses: nttld/setup-ndk@v1
+      uses: nttld/setup-ndk@v1.5.0
       with:
-        ndk-version: r28
+        ndk-version: r28b
 
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@v2.0.2
 
     - name: Build Encore JNI
       run: ndk-build


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/build.yml` to enhance compatibility and ensure the latest versions of dependencies are used. The changes include adding support for pull request events, as well as updating actions and tools to newer versions.

### Workflow enhancements:

* Added `pull_request` trigger to the workflow to run builds on pull request events targeting the `main` branch. (`.github/workflows/build.yml`, [.github/workflows/build.ymlR4-R6](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R4-R6))

### Dependency updates:

* Updated `actions/checkout` action from version `v4` to `v4.2.2` for improved stability and features. (`.github/workflows/build.yml`, [.github/workflows/build.ymlL29-R42](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L29-R42))
* Updated `nttld/setup-ndk` action from version `v1` to `v1.5.0` and changed the NDK version from `r28` to `r28b` for better compatibility. (`.github/workflows/build.yml`, [.github/workflows/build.ymlL29-R42](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L29-R42))
* Updated `oven-sh/setup-bun` action from version `v2` to `v2.0.2` to use the latest Bun setup. (`.github/workflows/build.yml`, [.github/workflows/build.ymlL29-R42](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L29-R42))