### PR TITLE
tree: Use `/proc` instead of `/dev` for file IPC

### DIFF
--- a/jni/include/encore.h
+++ b/jni/include/encore.h
@@ -22,11 +22,11 @@
 #define NOTIFY_TITLE "Encore Tweaks"
 #define LOG_TAG "EncoreTweaks"
 
-#define LOCK_FILE "/dev/encore_lockfile"
-#define LOG_FILE "/dev/encore_log"
-#define PROFILE_MODE "/dev/encore_mode"
-#define GAME_INFO "/dev/encore_game_info"
-#define GAMELIST "/dev/encore_gamelist"
+#define LOCK_FILE "/proc/encore_lockfile"
+#define LOG_FILE "/proc/encore_log"
+#define PROFILE_MODE "/proc/encore_mode"
+#define GAME_INFO "/proc/encore_game_info"
+#define GAMELIST "/proc/encore_gamelist"
 #define MODULE_PROP "/data/adb/modules/encore/module.prop"
 #define MODULE_UPDATE "/data/adb/modules/encore/update"
 

--- a/module/service.sh
+++ b/module/service.sh
@@ -42,7 +42,7 @@ echo "$default_gov" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 [ ! -f /data/encore/powersave_cpu_gov ] && echo "$default_gov" >/data/encore/powersave_cpu_gov
 
 # Copy gamelist to tmpfs
-cp /data/encore/gamelist.txt /dev/encore_gamelist
+cp /data/encore/gamelist.txt /proc/encore_gamelist
 
 # Start Encore Daemon
 encored

--- a/scripts/encore_utility.sh
+++ b/scripts/encore_utility.sh
@@ -58,7 +58,7 @@ Android SDK: $(getprop ro.build.version.sdk)
 Kernel: $(uname -r -m)
 *****************************************************
 
-$(</dev/encore_log)
+$(</proc/encore_log)
 EOF
 }
 
@@ -99,7 +99,7 @@ logcat() {
 "
 
 	# Tail log
-	tail -f /dev/encore_log | while read -r line; do
+	tail -f /proc/encore_log | while read -r line; do
 		timestamp="${line:0:23}"
 		level_char=$(echo "$line" | awk '{print $3}')
 		msg="${line:24}"

--- a/website/docs/guide/addon.md
+++ b/website/docs/guide/addon.md
@@ -11,7 +11,7 @@ Other module can watch current profile on Encore Tweaks and then apply their own
 
 ## File Interface
 
-### `/dev/encore_mode`
+### `/proc/encore_mode`
 
 **Description**: Contains the current performance profile state as a numeric value
 
@@ -24,7 +24,7 @@ Other module can watch current profile on Encore Tweaks and then apply their own
 | 2     | Normal          | Default operating mode                     |
 | 3     | PowerSave       | Battery saving mode                        |
 
-### `/dev/encore_game_info`
+### `/proc/encore_game_info`
 
 **Description**: Contains active game session information when games from the Encore Tweaks gamelist are running
 
@@ -42,5 +42,5 @@ If you find that the existing API doesn't meet your needs or is inconvenient to 
 
 ## Some tips
 
-1. Even though we could use same log file as Encore Tweaks (`/dev/encore_log`) for convenience, Addon modules should handles how the log is being written on the file to prevent write conflicts.
+1. Even though we could use same log file as Encore Tweaks (`/proc/encore_log`) for convenience, Addon modules should handles how the log is being written on the file to prevent write conflicts.
 2. We recommend using `inotify` to monitor file changes, there's also **[x-watcher](https://github.com/nikp123/x-watcher)** Library that conveniently handles `inotify` for you.

--- a/webui/src/scripts/webui_utils.js
+++ b/webui/src/scripts/webui_utils.js
@@ -46,7 +46,7 @@ const getModuleVersion = async () => {
 };
 
 const getCurrentProfile = async () => {
-  const output = await runCommand('cat /dev/encore_mode');
+  const output = await runCommand('cat /proc/encore_mode');
   let profile = "Unknown";
 
   switch(output) {
@@ -155,9 +155,9 @@ setupSwitch('dnd_switch', 'dnd_gameplay');
 const changeCPUGovernor = async (governor, config) => {
   await runCommand(`echo ${governor} >${configPath}/${config}`);
   if (config === "powersave_cpu_gov") {
-    await runCommand(`[ "$(</dev/encore_mode)" -eq 3 ] && encore_utility change_cpu_gov ${governor}`);
+    await runCommand(`[ "$(</proc/encore_mode)" -eq 3 ] && encore_utility change_cpu_gov ${governor}`);
   } else if (config === "custom_default_cpu_gov") {
-    await runCommand(`[ "$(</dev/encore_mode)" -eq 2 ] && encore_utility change_cpu_gov ${governor}`);
+    await runCommand(`[ "$(</proc/encore_mode)" -eq 2 ] && encore_utility change_cpu_gov ${governor}`);
   }
 };
 
@@ -176,7 +176,7 @@ const fetchCPUGovernors = async () => {
 /* ======================== GAMELIST MANAGEMENT ======================== */
 const fetchGamelist = async () => {
   const input = document.getElementById('gamelist_textarea');
-  const output = await runCommand(`cat /dev/encore_gamelist`);
+  const output = await runCommand(`cat /proc/encore_gamelist`);
   if (output.error) {
     showErrorModal("Unable to fetch Gamelist", output.error);
   } else {
@@ -187,7 +187,7 @@ const fetchGamelist = async () => {
 const saveGamelist = async () => {
   const input = document.getElementById('gamelist_textarea');
   const formattedList = input.value.trim().replace(/\n+/g, '|');
-  const result = await runCommand(`echo "${formattedList}" | tee /data/encore/gamelist.txt /dev/encore_gamelist >/dev/null`);
+  const result = await runCommand(`echo "${formattedList}" | tee /data/encore/gamelist.txt /proc/encore_gamelist >/dev/null`);
   result.error ? showErrorModal("Unable to save Gamelist", result.error) : toast('Gamelist saved successfully.');
 };
 


### PR DESCRIPTION
In UNIX, _`/dev` is the directory where all files representing physical hardware (or other resources available to the kernel._)[1] Encore exposes its file IPC interface in `/dev` which works, but is _semantically misleading_.
 
A more appropriate convention is to put these files inside `/proc`, which is also standard in most scenarios.

[1] https://en.wikipedia.org/wiki/Device_file#devfs