### PR TITLE
Perf Gov for 20 seconds then go back to default governor

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -56,5 +56,21 @@ if [ -f "$ENABLE_PPM" ]; then
 	echo 1 >"$ENABLE_PPM"
 fi
 
+# Test 
+# Sandevistan Boot
+
+change_cpu_gov() {
+	chmod 644 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+	echo "$1" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor >/dev/null
+	chmod 444 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+}
+
+change_cpu_gov performance
+
+sleep 10
+
+change_cpu_gov schedutil
+change_cpu_gov schedhorizon
+
 # Start Encore Daemon
 encored

--- a/module/service.sh
+++ b/module/service.sh
@@ -67,7 +67,7 @@ change_cpu_gov() {
 
 change_cpu_gov performance
 
-sleep 10
+sleep 20
 
 change_cpu_gov schedutil
 change_cpu_gov schedhorizon

--- a/scripts/encore_utility.sh
+++ b/scripts/encore_utility.sh
@@ -18,22 +18,20 @@
 # Config dir
 MODULE_CONFIG="/data/adb/.config/encore"
 
-# Isn't those already in encore_profiler?
+change_cpu_gov() {
+	chmod 644 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+	echo "$1" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+	chmod 444 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+}
 
-# change_cpu_gov() {
-# 	chmod 644 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-# 	echo "$1" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-# 	chmod 444 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-# }
-
-# set_dnd() {
-# 	case $1 in
-# 	# Turn off DND mode
-# 	0) cmd notification set_dnd off ;;
-# 	# Turn on DND mode
-# 	1) cmd notification set_dnd priority ;;
-# 	esac
-# }
+set_dnd() {
+	case $1 in
+	# Turn off DND mode
+	0) cmd notification set_dnd off ;;
+	# Turn on DND mode
+	1) cmd notification set_dnd priority ;;
+	esac
+}
 
 save_logs() {
 	[ ! -d /sdcard/Download ] && mkdir /sdcard/Download

--- a/scripts/encore_utility.sh
+++ b/scripts/encore_utility.sh
@@ -18,20 +18,22 @@
 # Config dir
 MODULE_CONFIG="/data/adb/.config/encore"
 
-change_cpu_gov() {
-	chmod 644 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-	echo "$1" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-	chmod 444 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
-}
+# Isn't those already in encore_profiler?
 
-set_dnd() {
-	case $1 in
-	# Turn off DND mode
-	0) cmd notification set_dnd off ;;
-	# Turn on DND mode
-	1) cmd notification set_dnd priority ;;
-	esac
-}
+# change_cpu_gov() {
+# 	chmod 644 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+# 	echo "$1" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+# 	chmod 444 /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+# }
+
+# set_dnd() {
+# 	case $1 in
+# 	# Turn off DND mode
+# 	0) cmd notification set_dnd off ;;
+# 	# Turn on DND mode
+# 	1) cmd notification set_dnd priority ;;
+# 	esac
+# }
 
 save_logs() {
 	[ ! -d /sdcard/Download ] && mkdir /sdcard/Download


### PR DESCRIPTION
This is actually a new feature on my new EnCorinVest 
I heard you add something like this back then but you remove it

You need to adapt the script tho, bcs I only give schedutil & schedhorizon on it