### PR TITLE
fix: prevent schedutil deadlock on Samsung Snapdragon devices

### DIFF
--- a/config/device_mitigation.json
+++ b/config/device_mitigation.json
@@ -2,5 +2,24 @@
   "default": {
     "items": ["DISABLE_DDR_TWEAK", "NO_PERFORMANCE_CPUGOV", "QCOM_NO_GPU_POWERSAVE"]
   },
-  "device_rules": {}
+  "device_rules": {
+    "snapdragon_samsung_schedutil_bug": {
+      "name": "Snapdragon/Samsung Schedutil Mitigation",
+      "description": "Prevents 100% CPU usage deadlock on Prime Core by blacklisting schedutil on Samsung Snapdragon kernels.",
+      "filter_type": "all",
+      "items": [
+        "NO_SCHEDUTIL_CPUGOV"
+      ],
+      "filter_condition": {
+        "soc": {
+          "operator": "regex",
+          "value": "(?i)(sm[0-9]+|qcom|qualcomm|snapdragon)"
+        },
+        "model": {
+          "operator": "regex",
+          "value": "(?i)(sm-|samsung)"
+        }
+      }
+    }
+  }
 }

--- a/jni/EncoreConfigStore.cpp
+++ b/jni/EncoreConfigStore.cpp
@@ -138,6 +138,21 @@ bool EncoreConfigStore::reload() {
     return load_config(config_path_);
 }
 
+// Skip bypass on pre-GKI kernels where 'walt' doesn't exist and 'schedutil' is safe.
+static bool is_governor_supported(const std::string &gov) {
+    std::ifstream file("/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors");
+    if (!file.is_open()) {
+        return false;
+    }
+    std::string available_gov;
+    while (file >> available_gov) {
+        if (available_gov == gov) {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::string EncoreConfigStore::read_default_cpu_governor() const {
     // Fallback governor
     std::string default_governor = "schedutil";
@@ -156,7 +171,7 @@ std::string EncoreConfigStore::read_default_cpu_governor() const {
     file.close();
 
     auto mitigations = device_mitigation_store.get_cached_mitigation_items(false);
-    if (mitigations.contains("NO_SCHEDUTIL_CPUGOV")) {
+    if (mitigations.contains("NO_SCHEDUTIL_CPUGOV") && is_governor_supported("walt")) {
         if (default_governor == "schedutil") {
             default_governor = "walt";
         }
@@ -229,7 +244,7 @@ bool EncoreConfigStore::parse_config(const rapidjson::Document &doc) {
     }
 
     auto mitigations = device_mitigation_store.get_cached_mitigation_items(new_config.preferences.use_device_mitigation);
-    if (mitigations.contains("NO_SCHEDUTIL_CPUGOV")) {
+    if (mitigations.contains("NO_SCHEDUTIL_CPUGOV") && is_governor_supported("walt")) {
         if (new_config.cpu_governor.balance == "schedutil") new_config.cpu_governor.balance = "walt";
         if (new_config.cpu_governor.powersave == "schedutil") new_config.cpu_governor.powersave = "walt";
     }

--- a/jni/EncoreConfigStore.cpp
+++ b/jni/EncoreConfigStore.cpp
@@ -25,6 +25,7 @@
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/stringbuffer.h>
 
+#include "DeviceMitigationStore.hpp"
 #include "EncoreConfigStore.hpp"
 
 bool EncoreConfigStore::load_config(const std::string &config_path) {
@@ -153,6 +154,14 @@ std::string EncoreConfigStore::read_default_cpu_governor() const {
     }
 
     file.close();
+
+    auto mitigations = device_mitigation_store.get_cached_mitigation_items(false);
+    if (mitigations.contains("NO_SCHEDUTIL_CPUGOV")) {
+        if (default_governor == "schedutil") {
+            default_governor = "walt";
+        }
+    }
+
     return default_governor;
 }
 
@@ -217,6 +226,12 @@ bool EncoreConfigStore::parse_config(const rapidjson::Document &doc) {
         if (gov.HasMember("powersave") && gov["powersave"].IsString()) {
             new_config.cpu_governor.powersave = gov["powersave"].GetString();
         }
+    }
+
+    auto mitigations = device_mitigation_store.get_cached_mitigation_items(new_config.preferences.use_device_mitigation);
+    if (mitigations.contains("NO_SCHEDUTIL_CPUGOV")) {
+        if (new_config.cpu_governor.balance == "schedutil") new_config.cpu_governor.balance = "walt";
+        if (new_config.cpu_governor.powersave == "schedutil") new_config.cpu_governor.powersave = "walt";
     }
 
     {

--- a/module/service.sh
+++ b/module/service.sh
@@ -30,6 +30,15 @@ rm -f "$MODULE_CONFIG/encore.log" "$MODULE_CONFIG/sysmon.log"
 # Parse Governor to use
 chmod 644 "$CPUFREQ/scaling_governor"
 default_gov=$(cat "$CPUFREQ/scaling_governor")
+
+# Add mitigation for Samsung Snapdragon Bug
+SOC_ID=$(cat "$MODULE_CONFIG/soc_recognition" 2>/dev/null)
+if [ "$SOC_ID" = "2" ] && getprop ro.product.brand | grep -iq "samsung"; then
+	if [ "$default_gov" = "schedutil" ]; then
+		default_gov="walt"
+	fi
+fi
+
 echo "$default_gov" >$MODULE_CONFIG/default_cpu_gov
 
 # Create cleanup script

--- a/module/service.sh
+++ b/module/service.sh
@@ -35,7 +35,9 @@ default_gov=$(cat "$CPUFREQ/scaling_governor")
 SOC_ID=$(cat "$MODULE_CONFIG/soc_recognition" 2>/dev/null)
 if [ "$SOC_ID" = "2" ] && getprop ro.product.brand | grep -iq "samsung"; then
 	if [ "$default_gov" = "schedutil" ]; then
-		default_gov="walt"
+		if grep -q "walt" "$CPUFREQ/scaling_available_governors"; then
+			default_gov="walt"
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Fixes #114

This PR fixes a critical bug where the `schedutil` CPU governor causes an infinite loop and 100% CPU usage on Samsung Snapdragon devices.

**Bug**
When we force the `schedutil` governor on modern Samsung Snapdragon devices, it creates a math problem. The generic Linux system uses PELT (smooth averages) to read CPU load, but Samsung hardware uses WALT (instant spikes). Because of this mismatch, `schedutil` gets confused and asks the hardware for maximum speed all the time. The hardware thermal limits (LMh) reject this request to stop overheating. However, `schedutil` doesn't know how to wait, so it retries the request millions of times per second. This endless loop completely freezes the Prime Core at 100% usage.

**Solution**
I created a global safety rule for Samsung Snapdragon devices. Now, the app and shell scripts will automatically block any requests for the `schedutil` governor on these specific devices. Instead, it will safely switch to the `walt` governor, which prevents the lockup completely.
