### PR TITLE
service: Implement `waitForServiceCompat` for older Andorid version

### DIFF
--- a/jni/base/BinderMonitor/BinderMonitor.cpp
+++ b/jni/base/BinderMonitor/BinderMonitor.cpp
@@ -286,6 +286,25 @@ static std::string transactReadString(AIBinder *binder, uint32_t tx, const char 
     return value;
 }
 
+/**
+ * @brief Waits for a service to register.
+ */
+static AIBinder *waitForServiceCompat(const char *name, int timeoutMs = 10000) {
+    if (BinderNDK_hasSymbol("AServiceManager_waitForService")) {
+        return AServiceManager_waitForService(name);
+    }
+
+    const int intervalMs = 100;
+    int waited = 0;
+    while (waited < timeoutMs) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(intervalMs));
+        waited += intervalMs;
+        AIBinder *binder = AServiceManager_getService(name);
+        if (binder) return binder;
+    }
+    return nullptr;
+}
+
 static bool queryIsInteractive() {
     return transactReadInt32(gState.powerBinder, gState.getCode(TxCode::IsInteractive), "android.os.IPowerManager", 0) != 0;
 }
@@ -422,7 +441,7 @@ bool BinderMonitor::initialize() {
         *s.out = AServiceManager_getService(s.name);
         if (!*s.out) {
             LOGW_TAG("BinderMonitor", "Service '{}' not immediately available, waiting...", s.name);
-            *s.out = AServiceManager_waitForService(s.name);
+            *s.out = waitForServiceCompat(s.name);
         }
         if (!*s.out) {
             LOGE_TAG("BinderMonitor", "Failed to acquire service '{}'", s.name);

--- a/jni/base/BinderNDK/BinderNDK.cpp
+++ b/jni/base/BinderNDK/BinderNDK.cpp
@@ -276,6 +276,12 @@ namespace {
 
 extern "C" {
 
+bool BinderNDK_hasSymbol(const char *name) {
+    std::call_once(g_init_flag, load_binder_ndk);
+    if (!g_libbinder_handle) return false;
+    return dlsym(g_libbinder_handle, name) != nullptr;
+}
+
 AIBinder *AServiceManager_getService(const char *instance) {
     FORWARD(AServiceManager_getService, nullptr, instance);
 }

--- a/jni/base/BinderNDK/BinderNDK.hpp
+++ b/jni/base/BinderNDK/BinderNDK.hpp
@@ -101,6 +101,18 @@ enum {
 extern "C" {
 
 // =============================================================================
+// Helper functions
+// =============================================================================
+
+/**
+ * @brief Checks whether a given libbinder_ndk.so symbol was found at load time.
+ *
+ * @param name Exact symbol name, e.g. "AServiceManager_waitForService".
+ * @return true if the symbol was resolved, false if it is missing or the library failed to load.
+ */
+bool BinderNDK_hasSymbol(const char *name);
+
+// =============================================================================
 // Service Manager
 // =============================================================================
 


### PR DESCRIPTION
waitForService is not introduced until API 31.